### PR TITLE
fix RPi compile error problem (and linux)

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -31,9 +31,10 @@ common:
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	ADDON_INCLUDES  = libs/link/include
+	ADDON_INCLUDES = src
+	ADDON_INCLUDES += libs/link/include
+       	ADDON_INCLUDES += libs/link/include/ableton
 	ADDON_INCLUDES += libs/link/modules/asio-standalone/asio/include
-	ADDON_INCLUDES += libs/link/modules/catch/include
 	
 	# any special flag that should be passed to the compiler when using this
 	# addon
@@ -54,7 +55,7 @@ common:
 	# in the src folders in libs and the root of the addon. if your addon needs
 	# to include files in different places or a different set of files per platform
 	# they can be specified here
-	ADDON_SOURCES  =  src/ofxAbletonLink.h
+	#ADDON_SOURCES  =  src/ofxAbletonLink.h
 
 	# some addons need resources to be copied to the bin/data folder of the project
 	# specify here any files that need to be copied, you can use wildcards like * and ?
@@ -64,11 +65,27 @@ common:
 	# a specific platform
 	# ADDON_LIBS_EXCLUDE  =
 
+	# when parsing the file system looking for sources exclude this for all or
+	# a specific platform
+	ADDON_SOURCES_EXCLUDE = libs/link/%
+
 #osx:
-#	ADDON_CFLAGS += -DLINK_PLATFORM_MACOSX=1
+	#ADDON_CFLAGS += -DLINK_PLATFORM_MACOSX=1
 
 #linux:
-#	ADDON_CFLAGS += -DLINK_PLATFORM_LINUX=1
+	#ADDON_CFLAGS += -DLINK_PLATFORM_LINUX=1
 
+#linuxarmv6l:
+	#ADDON_CFLAGS += -DLINK_PLATFORM_LINUX=1
+
+#linuxarmv7l:
+	#ADDON_CFLAGS += -DLINK_PLATFORM_LINUX=1
+
+#win_cb:
 #windows:
-#	ADDON_CFLAGS += -DLINK_PLATFORM_WINDOWS=1
+	#ADDON_CFLAGS += -DLINK_PLATFORM_WINDOWS=1
+
+
+#android/armeabi:
+
+#android/armeabi-v7a:


### PR DESCRIPTION
1. Exclude files which is not used for Ableton Link library itself.
2. Some of (#) comment out does not work because of indent.

see also https://github.com/comoc/ofxAbletonLink